### PR TITLE
BES-003 | add Github PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## :sauropod:&emsp;Description
+
+### Summary of changes
+
+/_ Add Summary here _/
+
+### Related Issue ticket number and link
+
+[BES-XXXX]()
+
+### Additional notes (e.g. motivation, context, etc.)
+
+/_ Add notes here _/
+
+### Type of change
+
+Please delete options that are not relevant.
+
+- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
+- [ ] :frog: New feature (non-breaking change which adds functionality)
+- [ ] :bowtie: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] :page_with_curl: This change requires a documentation update
+
+### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,15 @@
 ## Backen Tutorial -- various topics and concepts
 
 ###### Branch naming convention will be BES(Backend Series) and the brance count, starting from 001. So the branches will be
- - BES-001
- - BES-002
- - BES-003 and so on
 
+- BES-001
+- BES-002
+- BES-003 and so on
 
-###### Prettier runtime configuration ([Medium](https://javascript.plainenglish.io/exploring-the-core-a-series-on-understanding-the-root-of-a-node-project-prettier-2e199c9350f5))
+###### MDN Syntax : Basic writing and formatting syntax ([Github Docs article](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests))
+
+###### Prettier runtime configuration ([Medium article](https://javascript.plainenglish.io/exploring-the-core-a-series-on-understanding-the-root-of-a-node-project-prettier-2e199c9350f5))
+
+###### Creating a pull request template for your repository ([Github article](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository))
+
+###### GitHub Emoji Cheat Sheet([link](https://gist.github.com/mayurchhapra/3508291362c42d983fe5774e71f70207))


### PR DESCRIPTION
### Additional Notes
 - when creating a PR a default template should open up to the PR creator.

### Summary of changes
 - added .github folder and pull_request_template.md inside it.
 - added PR template, github emoji(s) and MDN Syntax related link in Readme.md
 - Sample emojis:&ensp; :paw_prints: &emsp;|&ensp; :flipper: